### PR TITLE
[doc] Remove Azure from the Faster metrics part

### DIFF
--- a/content/en/integrations/faq/cloud-metric-delay.md
+++ b/content/en/integrations/faq/cloud-metric-delay.md
@@ -44,7 +44,7 @@ When creating monitors in Datadog, a warning message displays if you choose a de
 
 To obtain metrics with virtually zero delay, install the Datadog Agent on your cloud hosts when possible. Refer to the documentation on [installing the Datadog Agent on your cloud instances][1].
 
-On the Datadog side for the AWS, Azure, and GCP integrations, we may be able to speed up the default metric crawler for all metrics. Additionally, for AWS, Datadog has namespace specific crawlers. Contact [Datadog support][2] for more information.
+On the Datadog side for the AWS and GCP integrations, we may be able to speed up the default metric crawler for all metrics. Additionally, for AWS, Datadog has namespace specific crawlers. Contact [Datadog support][2] for more information.
 
 ## Further Reading
 


### PR DESCRIPTION


More info on slack: https://dd.slack.com/archives/C02FPP4JQHX/p1733494498311969

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Remove Azure rom the Faster metrics option as we do not offer that possibility

### Motivation
A customer reached out to increase the Azure crawler frequency because it was an option as stated in the docs

https://datadog.zendesk.com/agent/tickets/1952393

### Preview link
https://docs.datadoghq.com/integrations/guide/cloud-metric-delay/#faster-metrics:~:text=On%20the%20Datadog%20side%20for%20the%20AWS%2C%20Azure%2C%20and%20GCP%20integrations%2C%20Datadog%20may%20be%20able%20to%20speed%20up%20the%20default%20metric%20crawler%20for%20all%20metrics.%20Additionally%2C%20for%20AWS%2C%20Datadog%20has%20namespace%20specific%20crawlers.%20Contact%20Datadog%20support%20for%20more%20information.

<!-- This is the base preview link. This currently only works if you are in the Datadog organization and working off of a branch - it will not work with a fork. 

Replace the branch name and add the complete path:
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

For example, for branch "lucas/update-dotnet-tracing" that updates the docs in path "https://docs.datadoghq.com/tracing/languages/dotnet/", this is the preview link:
https://docs-staging.datadoghq.com/lucas/update-dotnet-tracing/tracing/languages/dotnet/
-->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
